### PR TITLE
Fixed size not being displayed and removed "shared" from table

### DIFF
--- a/API.py
+++ b/API.py
@@ -118,7 +118,7 @@ class GoogleAPI():
                 name=f.get("name"),
                 base64=None,
                 mime=f.get("mimeType"),
-                size=f.get("size"),
+                size=props.get("size"),
                 size_numeric=props.get("size_numeric"),
                 encoded_size=props.get("encoded_size"),
                 id=f.get("id"),

--- a/uds.py
+++ b/uds.py
@@ -213,11 +213,11 @@ class UDS():
             saved_bytes = 0
             for item in items:
                 record = [item.name, item.size,
-                          item.encoded_size, item.id_, item.shared]
+                          item.encoded_size, item.id_]
                 table.append(record)
 
             print(tabulate(table, headers=[
-                  'Name', 'Size', 'Encoded', 'ID', 'Shared']))
+                  'Name', 'Size', 'Encoded', 'ID']))
 
     def actions(self, action, args):
         switcher = {


### PR DESCRIPTION
Size was not being displayed properly. That's now fixed.

"Shared" was always empty since it contains a boolean value, so I removed it from the table. It is possible to display who this file is shared with (if anyone) but it doesn't seem to be worth the trouble.
