### PR TITLE
File hash does not match if we haven't closed the file handler.

### DIFF
--- a/uds.py
+++ b/uds.py
@@ -115,9 +115,8 @@ class UDS():
             # Append decoded part to file
             f.write(decoded_part)
 
-        file_hash = self.hash_file(f.name)
-
         f.close()
+        file_hash = self.hash_file(f.name)
 
         original_hash = folder.get("properties").get("sha256")
         if (file_hash != original_hash and original_hash is not None):


### PR DESCRIPTION
File hash does not match if we haven't closed the file handler before calculating hash. It tries to hash a nonexistant file for which the hash comes out different than the original. This blocks download of file 