### PR TITLE
allow regular expressions when listing files

### DIFF
--- a/API.py
+++ b/API.py
@@ -123,7 +123,8 @@ class GoogleAPI():
         """
         q = "properties has {key='uds' and value='true'} and trashed=false"
 
-        if (query is not None):
+        #add contains subquery not a regular expression query
+        if (query is not None and not query.startswith("re:")):
             q += " and name contains '%s'" % query
 
         # Call the Drive v3 API
@@ -133,6 +134,18 @@ class GoogleAPI():
             fields="nextPageToken, files(id, name, properties, mimeType)").execute()
 
         items = results.get('files', [])
+
+        # use python's re module to filter files
+        if (query is not None and query.startswith("re:")):
+           import re
+           _re=re.compile(query[3:])
+           _items=[]
+           for item in items:
+               _name=item.get("name")
+               if (_re.match(_name)):
+                  _items.append(item)
+
+           items=_items
 
         files = []
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ python uds.py list
 arguments: query
 ```
 
+If query starts with re:, we use python's builtin re module to filter the files.
+
+```
+> python uds.py list "re:^Desktop"
+No UDS files found
+
+> python uds.py list "re:.*04.iso"
+Name                      Size   Encoded    ID
+------------------------  -----  ---------  ---------------------------------  
+Ubuntu.Desktop.16.04.iso  810 MB  1.1 GB    1fc6JGpX6vUWiwflL1jBxM1YpuMHFAms8
+
+```
+
+
 ### Download
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ arguments: query
 
 If query starts with re:, we use python's builtin re module to filter the files.
 
+Let us see if any files start with 'Desktop'
 ```
 > python uds.py list "re:^Desktop"
 No UDS files found
+```
 
+Let us see if any files end with '04.iso'
+```
 > python uds.py list "re:.*04.iso"
 Name                      Size   Encoded    ID
 ------------------------  -----  ---------  ---------------------------------  

--- a/README.md
+++ b/README.md
@@ -56,7 +56,23 @@ Also supports searching with a query!
 Name                      Size   Encoded    ID
 ------------------------  -----  ---------  ---------------------------------  
 Ubuntu.Desktop.18.10.iso  1.1 GB  1.3 GB    1RzzVfN9goHMTkM1Hf1FUWUVS_2R3GK7D
+
+
+If query starts with re:, we use python's builtin re module to filter the files.
+
+Let us see if any files start with 'Desktop'
+
+> python uds.py list "re:^Desktop"
+No UDS files found
+
+Let us see if any files end with '04.iso'
+
+> python uds.py list "re:.*04.iso"
+Name                      Size   Encoded    ID
+------------------------  -----  ---------  ---------------------------------  
+Ubuntu.Desktop.16.04.iso  810 MB  1.1 GB    1fc6JGpX6vUWiwflL1jBxM1YpuMHFAms8
 ```
+
 
 ```
 [Layout]
@@ -64,24 +80,6 @@ python uds.py list
 
 arguments: query
 ```
-
-If query starts with re:, we use python's builtin re module to filter the files.
-
-Let us see if any files start with 'Desktop'
-```
-> python uds.py list "re:^Desktop"
-No UDS files found
-```
-
-Let us see if any files end with '04.iso'
-```
-> python uds.py list "re:.*04.iso"
-Name                      Size   Encoded    ID
-------------------------  -----  ---------  ---------------------------------  
-Ubuntu.Desktop.16.04.iso  810 MB  1.1 GB    1fc6JGpX6vUWiwflL1jBxM1YpuMHFAms8
-
-```
-
 
 ### Download
 

--- a/uds.py
+++ b/uds.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from googleapiclient.http import MediaIoBaseUpload
 from googleapiclient.http import MediaIoBaseDownload


### PR DESCRIPTION
Allow users to use regular expressions when listing files.  Start all queries with re: to differentiate a "contains" query (which is supported by google docs) by a query done by python's re module.