### PR TITLE
Fix import error due to typo

### DIFF
--- a/uds.py
+++ b/uds.py
@@ -16,7 +16,7 @@ from googleapiclient.http import MediaIoBaseUpload
 from tabulate import tabulate
 from tqdm import tqdm
 
-import encoder
+import Encoder as encoder
 import file_parts
 from api import *
 from api import GoogleAPI


### PR DESCRIPTION
The module `Encoder` was wrongly imported as `encoder`, an import error was throwing due to this. 
fixed it by importing `Encoder as encoder`