### PR TITLE
Fix getting original_hash

### DIFF
--- a/uds.py
+++ b/uds.py
@@ -118,7 +118,7 @@ class UDS:
 
         f.close()
 
-        original_hash = folder.get("md5Checksum")
+        original_hash = folder.get("properties", {}).get("md5")
         if original_hash is not None and file_hash != original_hash:
             print("Failed to verify hash\nDownloaded file had hash {} compared to original {}".format(
                 file_hash, original_hash))


### PR DESCRIPTION
Use the proper function to get the original hash via the API. The current implementation just returns `None `all the time, basically skipping the hash check.