### PR TITLE
Update encoder.py

### DIFF
--- a/encoder.py
+++ b/encoder.py
@@ -2,7 +2,7 @@ import base64
 
 
 def encode(chunk):
-    enc = str(base64.encodestring(chunk), 'utf-8')
+    enc = str(base64.encodebytes(chunk), 'utf-8')
     return enc
 
 


### PR DESCRIPTION
Changed encodestring to the newer encodebytes for compatibility with newer python version(s) (python 3.9 and above I think)

Screenshot of update log that removed the encodestring alias:
![image](https://user-images.githubusercontent.com/59830101/97026163-de9da980-157a-11eb-9a9f-563eafcfdb6a.png)

